### PR TITLE
feat(llmisvc): template preset images and namespace (#4901)

### DIFF
--- a/charts/kserve-runtime-configs/README.md
+++ b/charts/kserve-runtime-configs/README.md
@@ -35,6 +35,15 @@ $ helm install kserve-runtime-configs oci://ghcr.io/kserve/charts/kserve-runtime
 | kserve.inferenceservice.resources.requests.cpu | string | `"1"` |  |
 | kserve.inferenceservice.resources.requests.memory | string | `"2Gi"` |  |
 | kserve.llmisvcConfigs.enabled | bool | `false` |  |
+| kserve.llmisvcConfigs.imagePullPolicy | string | `"IfNotPresent"` |  |
+| kserve.llmisvcConfigs.images.routingSidecar.image | string | `"ghcr.io/llm-d/llm-d-routing-sidecar"` |  |
+| kserve.llmisvcConfigs.images.routingSidecar.tag | string | `"v0.7.1"` |  |
+| kserve.llmisvcConfigs.images.scheduler.image | string | `"ghcr.io/llm-d/llm-d-inference-scheduler"` |  |
+| kserve.llmisvcConfigs.images.scheduler.tag | string | `"v0.7.1"` |  |
+| kserve.llmisvcConfigs.images.tokenizer.image | string | `"ghcr.io/llm-d/llm-d-uds-tokenizer"` |  |
+| kserve.llmisvcConfigs.images.tokenizer.tag | string | `"v0.7.1"` |  |
+| kserve.llmisvcConfigs.images.workload.image | string | `"ghcr.io/llm-d/llm-d-cuda"` |  |
+| kserve.llmisvcConfigs.images.workload.tag | string | `"v0.6.0"` |  |
 | kserve.opentelemetryCollector.metricReceiverEndpoint | string | `"keda-otel-scaler.keda.svc:4317"` |  |
 | kserve.opentelemetryCollector.metricScalerEndpoint | string | `"keda-otel-scaler.keda.svc:4318"` |  |
 | kserve.opentelemetryCollector.resource.cpuLimit | string | `"1"` |  |

--- a/charts/kserve-runtime-configs/templates/_helpers.tpl
+++ b/charts/kserve-runtime-configs/templates/_helpers.tpl
@@ -48,3 +48,45 @@ app.kubernetes.io/name: {{ include "kserve-runtime-configs.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/*
+Repoint the llm-d preset images from values.
+
+The LLMInferenceServiceConfig presets embed controller-side Go templates and are
+NOT parseable YAML, so we cannot fromYaml/deepMerge them — only string-replace.
+The search pattern is keyed on the ORIGINAL hardcoded repo (tag-agnostic), so a
+tag bump in config/llmisvcconfig keeps getting repointed. regexReplaceAllLiteral
+avoids "$" expansion in the replacement.
+
+Usage: include "kserve-runtime-configs.replaceLLMImages" (list $content .Values)
+*/}}
+{{- define "kserve-runtime-configs.replaceLLMImages" -}}
+{{- $content := index . 0 -}}
+{{- $imgs := (((index . 1).kserve | default dict).llmisvcConfigs | default dict).images | default dict -}}
+{{- $map := dict
+    "ghcr.io/llm-d/llm-d-cuda" ($imgs.workload | default dict)
+    "ghcr.io/llm-d/llm-d-routing-sidecar" ($imgs.routingSidecar | default dict)
+    "ghcr.io/llm-d/llm-d-inference-scheduler" ($imgs.scheduler | default dict)
+    "ghcr.io/llm-d/llm-d-uds-tokenizer" ($imgs.tokenizer | default dict) -}}
+{{- range $orig, $img := $map -}}
+{{- if and $img.image $img.tag -}}
+{{- $pattern := printf "%s:[^\\s\"']+" ($orig | replace "." "\\.") -}}
+{{- $content = regexReplaceAllLiteral $pattern $content (printf "%s:%s" $img.image $img.tag) -}}
+{{- end -}}
+{{- end -}}
+{{- $content -}}
+{{- end -}}
+
+{{/*
+Apply imagePullPolicy to every preset container. The presets ship
+"imagePullPolicy: IfNotPresent", so a plain replace covers all of them and is a
+no-op when the value is left at the default.
+
+Usage: include "kserve-runtime-configs.applyLLMImagePullPolicy" (list $content .Values)
+*/}}
+{{- define "kserve-runtime-configs.applyLLMImagePullPolicy" -}}
+{{- $content := index . 0 -}}
+{{- $llmisvcConfigs := ((index . 1).kserve | default dict).llmisvcConfigs | default dict -}}
+{{- $policy := $llmisvcConfigs.imagePullPolicy | default "IfNotPresent" -}}
+{{- $content | replace "imagePullPolicy: IfNotPresent" (printf "imagePullPolicy: %s" $policy) -}}
+{{- end -}}
+

--- a/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/templates/llmisvcconfigs/resources.yaml
@@ -1,3 +1,9 @@
 {{- if .Values.kserve.llmisvcConfigs.enabled }}
-{{ .Files.Get "files/llmisvcconfigs/resources.yaml" }}
+{{- /* Presets are intentionally non-YAML (controller-side Go templates), so we
+       string-transform the blob rather than tpl/fromYaml it. */ -}}
+{{- $c := .Files.Get "files/llmisvcconfigs/resources.yaml" -}}
+{{- $c = include "kserve-common.replaceNamespace" (list $c .Release.Namespace) -}}
+{{- $c = include "kserve-runtime-configs.replaceLLMImages" (list $c .Values) -}}
+{{- $c = include "kserve-runtime-configs.applyLLMImagePullPolicy" (list $c .Values) -}}
+{{ $c }}
 {{- end }}

--- a/charts/kserve-runtime-configs/values.yaml
+++ b/charts/kserve-runtime-configs/values.yaml
@@ -2,6 +2,25 @@ kserve:
   version: v0.19.0
   llmisvcConfigs:
     enabled: false
+    # Override the llm-d preset images. The repo is matched on its original
+    # value, so a tag-only bump in config/llmisvcconfig still gets repointed.
+    images:
+      workload:
+        image: ghcr.io/llm-d/llm-d-cuda
+        tag: v0.6.0
+      routingSidecar:
+        image: ghcr.io/llm-d/llm-d-routing-sidecar
+        tag: v0.7.1
+      scheduler:
+        image: ghcr.io/llm-d/llm-d-inference-scheduler
+        tag: v0.7.1
+      tokenizer:
+        image: ghcr.io/llm-d/llm-d-uds-tokenizer
+        tag: v0.7.1
+    # Applied to every preset container (presets ship IfNotPresent).
+    imagePullPolicy: IfNotPresent
+    # imagePullSecrets is not yet templated for presets: the preset blob has no
+    # such field and is not parseable YAML, so it cannot be injected safely. TODO.
   servingruntime:
     enabled: false
     modelNamePlaceholder: "{{.Name}}"

--- a/config/llmisvcconfig/configuration.yaml
+++ b/config/llmisvcconfig/configuration.yaml
@@ -1,0 +1,17 @@
+# Point the kustomize "images" transformer at the non-standard image paths
+# inside LLMInferenceServiceConfig presets so downstream overlays (and the
+# generated Helm chart) can override the llm-d image repos/tags.
+# Mirrors config/storagecontainers/configuration.yaml.
+images:
+- kind: LLMInferenceServiceConfig
+  path: spec/template/containers/image
+- kind: LLMInferenceServiceConfig
+  path: spec/template/initContainers/image
+- kind: LLMInferenceServiceConfig
+  path: spec/worker/containers/image
+- kind: LLMInferenceServiceConfig
+  path: spec/prefill/template/containers/image
+- kind: LLMInferenceServiceConfig
+  path: spec/prefill/worker/containers/image
+- kind: LLMInferenceServiceConfig
+  path: spec/router/scheduler/template/containers/image

--- a/config/llmisvcconfig/kustomization.yaml
+++ b/config/llmisvcconfig/kustomization.yaml
@@ -13,3 +13,23 @@ resources:
   - config-llm-template.yaml
   - config-llm-tracing.yaml
   - config-llm-worker-data-parallel.yaml
+
+# Teach the images transformer about the nested image paths in the presets.
+configurations:
+  - configuration.yaml
+
+# Defaults match the current pins, so `kustomize build` output is unchanged.
+# Overlays can override newName/newTag to repoint the llm-d images.
+images:
+  - name: ghcr.io/llm-d/llm-d-cuda
+    newName: ghcr.io/llm-d/llm-d-cuda
+    newTag: v0.6.0
+  - name: ghcr.io/llm-d/llm-d-routing-sidecar
+    newName: ghcr.io/llm-d/llm-d-routing-sidecar
+    newTag: v0.7.1
+  - name: ghcr.io/llm-d/llm-d-inference-scheduler
+    newName: ghcr.io/llm-d/llm-d-inference-scheduler
+    newTag: v0.7.1
+  - name: ghcr.io/llm-d/llm-d-uds-tokenizer
+    newName: ghcr.io/llm-d/llm-d-uds-tokenizer
+    newTag: v0.7.1


### PR DESCRIPTION
## Summary
Make the llm-d `LLMInferenceServiceConfig` preset images and install namespace configurable on **both** the kustomize and Helm delivery paths, with byte-identical default output. Addresses kserve/kserve#4901.

## Changes
**Kustomize source (`config/llmisvcconfig/`)**
- `configuration.yaml` (new) — points the images transformer at the six nested image paths in the CRD (template/worker/prefill containers + initContainers + scheduler).
- `kustomization.yaml` — pins the four llm-d images at their current values, so `kustomize build` output is unchanged and overlays can override `newName`/`newTag`.

**Helm (`charts/kserve-runtime-configs`)**
- Preset blob now flows through a string-transform chain (`replaceNamespace` + chart-local `replaceLLMImages` + `applyLLMImagePullPolicy`) instead of a bare `.Files.Get`. The presets embed controller-side Go templates and are not parseable YAML, so `tpl`/`fromYaml`/`deepMerge` cannot be used.
- New values: `kserve.llmisvcConfigs.images.*` and `imagePullPolicy`.
- Presets now install into the release namespace instead of always `kserve`.

**imagePullSecrets** is intentionally deferred — presets have no such field, so it would require fragile insertion into the non-YAML blob (no safe precedent).

## Verification
- `kustomize build config/llmisvcconfig` byte-identical to the committed blob (drift guard).
- Overlay override repoints all 9 cuda paths + scheduler; others untouched.
- `helm template --set ...enabled=true -n my-ns` → namespace replaced ×8, `GlobalConfig` directives preserved, image/tag/pullPolicy overrides applied.
- `lint-helm.sh` + `verify-helm-helpers.sh` pass; helm-docs README regenerated.

See `wiki/llmisvc/charts-overview.md` and `wiki/llmisvc/4901-helm-templating.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable image repositories, tags, and pull policies for LLMISvc presets across Helm and kustomize deployments.
  * Improved preset namespace installation handling.

* **Documentation**
  * Added comprehensive guide explaining Helm/kustomize templating strategy for LLMISvc presets.
  * Added chart generation and synchronization overview documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->