### PR TITLE
fix(llmisvc): actionable error when a required preset is missing (#4900)

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -151,7 +151,24 @@ func (r *LLMISVCReconciler) reconcileBaseRefs(ctx context.Context, llmSvc *v1alp
 
 		var cfgNotFound *configNotFoundError
 		if errors.As(err, &cfgNotFound) {
-			llmSvc.MarkPresetsCombinedNotReady("ConfigNotFound", cfgNotFound.Error())
+			msg := cfgNotFound.Error()
+			eventReason := "ConfigNotFound"
+			if WellKnownDefaultConfigs.Has(cfgNotFound.Name) {
+				// A missing well-known preset almost always means the runtime
+				// configs were never installed; make that actionable instead of
+				// a silent stall.
+				msg = fmt.Sprintf("required preset %q for the selected topology is not installed in %v; "+
+					"install the runtime configs (e.g. `helm ... --set kserve.llmisvcConfigs.enabled=true`), "+
+					"or supply the workload section inline or via spec.baseRefs",
+					cfgNotFound.Name, cfgNotFound.Namespaces)
+				eventReason = "PresetMissing"
+			}
+			// Keep the condition reason stable ("ConfigNotFound") so existing
+			// watchers and assertions stay valid.
+			llmSvc.MarkPresetsCombinedNotReady("ConfigNotFound", "%s", msg)
+			if r.EventRecorder != nil {
+				r.Eventf(llmSvc, corev1.EventTypeWarning, eventReason, "%s", msg)
+			}
 			return nil, nil // watch on LLMInferenceServiceConfig re-triggers when the config is recreated
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_reconcile_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_reconcile_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -128,4 +129,43 @@ func TestReconcileBaseRefs_PreservesAppliedConfigRefsWhenStopped(t *testing.T) {
 	assert.NotNil(t, combined)
 
 	assert.Equal(t, existingRefs, llmSvc.Status.AppliedConfigRefs, "AppliedConfigRefs should be preserved when service is stopped")
+}
+
+// A model-only service still relies on the well-known template preset; if it is
+// missing the failure must be actionable (enriched message + PresetMissing event).
+func TestReconcileBaseRefs_MissingWellKnownPresetIsActionable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha2.AddToScheme(scheme))
+
+	recorder := record.NewFakeRecorder(10)
+	reconciler := &LLMISVCReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme).Build(),
+		EventRecorder: recorder,
+	}
+
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-model-only",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{}, // single-node, no inline template
+	}
+
+	combined, err := reconciler.reconcileBaseRefs(t.Context(), llmSvc, &Config{})
+	assert.NoError(t, err)
+	assert.Nil(t, combined)
+
+	cond := llmSvc.Status.GetCondition(v1alpha2.PresetsCombined)
+	require.NotNil(t, cond)
+	assert.Equal(t, "ConfigNotFound", cond.Reason, "condition reason stays stable")
+	assert.Contains(t, cond.Message, "not installed")
+	assert.Contains(t, cond.Message, "helm")
+
+	select {
+	case ev := <-recorder.Events:
+		assert.Contains(t, ev, "PresetMissing")
+		assert.Contains(t, ev, "Warning")
+	default:
+		t.Fatal("expected a PresetMissing warning event")
+	}
 }


### PR DESCRIPTION
## Summary
When a well-known `LLMInferenceServiceConfig` preset for the active topology is not installed, the controller previously surfaced a bare `ConfigNotFound` and stalled silently. Make it actionable. Addresses kserve/kserve#4900.

## Changes
In `reconcileBaseRefs` (`config_merge.go`):
- Keep the `PresetsCombined` reason `ConfigNotFound` (stable for existing watchers and tests).
- For a missing **well-known** preset, enrich the message ("install the runtime configs … or supply the section inline / via baseRefs") and emit a `PresetMissing` warning event. The event is nil-guarded for the recorder-less unit reconcilers.
- User baseRef / non-well-known misses keep the existing message and get a `ConfigNotFound` event.

## Diagnosis note (v1alpha2)
The issue cites pre-`v1alpha2` code. In current code, `combineBaseRefsConfig` injects only the active-topology preset, so the literal "opt out of prefill but still need its preset" case no longer reproduces (handled by topology). The remaining gap was the silent stall, which this addresses.

## Why no self-supplied opt-out guard
A guard that skips a preset when the user supplies that workload section was prototyped, tested against the full suite, and **reverted**: the well-known presets are the foundation a user's spec is merged on top of (they provide baseline container fields such as probe handlers). Skipping one when the user supplies a *partial* container produces an invalid Deployment (existing test `controller_int_test.go:60` — `livenessProbe: must specify a handler type`). The router `HasRef`/`HasRefs` guards are safe only because a `Pool`/`Route` ref is a complete replacement, not a partial overlay.

## Verification
- Unit: model-only service against an empty client → reason `ConfigNotFound` + enriched message + `PresetMissing` event.
- **Full envtest suite green: 220 specs, 0 failures (1254s).**

See `wiki/llmisvc/4900-preset-resilience.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)