### PR TITLE
test: add NodeSelector/NodeName/ServiceAccountName coverage

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -187,6 +187,65 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 				},
 			},
 		},
+
+		// NodeName and NodeSelector are mutually exclusive in practice: setting
+		// spec.nodeName binds the pod directly to a node and bypasses the
+		// scheduler, so a NodeSelector would never be evaluated. Keep them in
+		// separate scenarios so each field's propagation is verified on its own.
+		"with node selector": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-selector-ig",
+				Namespace: "node-selector-ig-namespace",
+				Annotations: map[string]string{
+					"serving.kserve.io/deploymentMode": string(constants.Standard),
+				},
+			},
+
+			Spec: InferenceGraphSpec{
+				Nodes: map[string]InferenceRouter{
+					GraphRootNodeName: {
+						RouterType: Sequence,
+						Steps: []InferenceStep{
+							{
+								InferenceTarget: InferenceTarget{
+									ServiceURL: "http://someservice.example.com",
+								},
+							},
+						},
+					},
+				},
+				NodeSelector: map[string]string{
+					"disktype": "ssd",
+				},
+				ServiceAccountName: "graph-sa",
+			},
+		},
+
+		"with node name": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node-name-ig",
+				Namespace: "node-name-ig-namespace",
+				Annotations: map[string]string{
+					"serving.kserve.io/deploymentMode": string(constants.Standard),
+				},
+			},
+
+			Spec: InferenceGraphSpec{
+				Nodes: map[string]InferenceRouter{
+					GraphRootNodeName: {
+						RouterType: Sequence,
+						Steps: []InferenceStep{
+							{
+								InferenceTarget: InferenceTarget{
+									ServiceURL: "http://someservice.example.com",
+								},
+							},
+						},
+					},
+				},
+				NodeName: "node-1",
+			},
+		},
 	}
 
 	expectedPodSpecs := map[string]*corev1.PodSpec{
@@ -340,6 +399,79 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 				},
 			},
 		},
+		"with node selector": {
+			Containers: []corev1.Container{
+				{
+					Image: "kserve/router:v0.10.0",
+					Name:  "node-selector-ig",
+					Args: []string{
+						"--graph-json",
+						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"nodeSelector\":{\"disktype\":\"ssd\"},\"serviceAccountName\":\"graph-sa\"}",
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					ReadinessProbe: expectedReadinessProbe,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               proto.Bool(false),
+						RunAsNonRoot:             proto.Bool(true),
+						ReadOnlyRootFilesystem:   proto.Bool(true),
+						AllowPrivilegeEscalation: proto.Bool(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{corev1.Capability("ALL")},
+						},
+					},
+				},
+			},
+			AutomountServiceAccountToken: proto.Bool(false),
+			ImagePullSecrets:             []corev1.LocalObjectReference{},
+			NodeSelector: map[string]string{
+				"disktype": "ssd",
+			},
+			ServiceAccountName: "graph-sa",
+		},
+		"with node name": {
+			Containers: []corev1.Container{
+				{
+					Image: "kserve/router:v0.10.0",
+					Name:  "node-name-ig",
+					Args: []string{
+						"--graph-json",
+						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"nodeName\":\"node-1\"}",
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					},
+					ReadinessProbe: expectedReadinessProbe,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:               proto.Bool(false),
+						RunAsNonRoot:             proto.Bool(true),
+						ReadOnlyRootFilesystem:   proto.Bool(true),
+						AllowPrivilegeEscalation: proto.Bool(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{corev1.Capability("ALL")},
+						},
+					},
+				},
+			},
+			AutomountServiceAccountToken: proto.Bool(false),
+			ImagePullSecrets:             []corev1.LocalObjectReference{},
+			NodeName:                     "node-1",
+		},
 	}
 
 	scenarios := []struct {
@@ -372,6 +504,16 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 			name:     "Inference graph with tolerations",
 			args:     args{testIGSpecs["with tolerations"], &routerConfig},
 			expected: expectedPodSpecs["with tolerations"],
+		},
+		{
+			name:     "Inference graph with node selector and service account",
+			args:     args{testIGSpecs["with node selector"], &routerConfig},
+			expected: expectedPodSpecs["with node selector"],
+		},
+		{
+			name:     "Inference graph with node name",
+			args:     args{testIGSpecs["with node name"], &routerConfig},
+			expected: expectedPodSpecs["with node name"],
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds table-driven test coverage for pod-scheduling and identity fields that
`createInferenceGraphPodSpec` propagates from `InferenceGraphSpec` to the router
`PodSpec` but that were previously unverified: `NodeSelector`, `NodeName`, and
`ServiceAccountName`. Without coverage, a future refactor could silently drop one
of these lines and no test would catch the regression.

`NodeSelector` and `NodeName` are exercised in **separate** scenarios rather than a
single combined case: setting `spec.nodeName` binds the pod directly to a node and
bypasses the scheduler, so a `NodeSelector` would never be evaluated alongside it.
Keeping them apart verifies each field's propagation on its own and avoids implying
that the combination is a useful configuration.

This is a test-only change; no production code is modified.

**Which issue(s) this PR fixes**:
Fixes #5752

**Feature/Issue validation/testing**:

Added two scenarios to `TestCreateInferenceGraphPodSpec`:
- "Inference graph with node selector and service account" — asserts `PodSpec.NodeSelector`, `PodSpec.ServiceAccountName`, and that both appear in the router `--graph-json` argument.
- "Inference graph with node name" — asserts `PodSpec.NodeName` and that `nodeName` appears in `--graph-json`.

- [x] `go test ./pkg/controller/v1alpha1/inferencegraph/ -run TestCreateInferenceGraphPodSpec` — PASS (6/6 subtests)
- [x] `gofmt -l` — clean; `go vet ./pkg/controller/v1alpha1/inferencegraph/` — clean

- Logs
```
--- PASS: TestCreateInferenceGraphPodSpec (0.01s)
    --- PASS: TestCreateInferenceGraphPodSpec/Inference_graph_with_node_selector_and_service_account (0.00s)
    --- PASS: TestCreateInferenceGraphPodSpec/Inference_graph_with_node_name (0.00s)
PASS
```

**Special notes for your reviewer**:

Follows the existing table-driven pattern in `raw_ig_test.go` (input `InferenceGraph`
-> expected `PodSpec` -> `cmp.Diff` assertion). No new production behavior.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
NONE
```
