### PR TITLE
feat(inferencegraph): add minReplicas defaulting webhook

### DIFF
--- a/charts/kserve-resources/files/kserve/resources.yaml
+++ b/charts/kserve-resources/files/kserve/resources.yaml
@@ -558,6 +558,38 @@ metadata:
   labels:
     app.kubernetes.io/component: kserve
     app.kubernetes.io/name: kserve
+  name: inferencegraph.serving.kserve.io
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kserve-webhook-server-service
+      namespace: kserve
+      path: /mutate-serving-kserve-io-v1alpha1-inferencegraph
+  failurePolicy: Fail
+  name: inferencegraph.kserve-webhook-server.defaulter
+  rules:
+  - apiGroups:
+    - serving.kserve.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferencegraphs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kserve/serving-cert
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kserve
+    app.kubernetes.io/name: kserve
   name: inferenceservice.serving.kserve.io
 webhooks:
 - admissionReviewVersions:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -264,11 +264,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = ctrl.NewWebhookManagedBy(mgr).
-		For(&v1alpha1.InferenceGraph{}).
-		WithValidator(&v1alpha1.InferenceGraphValidator{}).
-		Complete(); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "v1alpha1")
+	if err = v1alpha1.SetupInferenceGraphWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "v1alpha1.InferenceGraph")
 		os.Exit(1)
 	}
 

--- a/config/default/inferencegraph_mutatingwebhook_cainjection_patch.yaml
+++ b/config/default/inferencegraph_mutatingwebhook_cainjection_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: inferencegraph.serving.kserve.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(kserveNamespace)/serving-cert
+webhooks:
+  - name: inferencegraph.kserve-webhook-server.defaulter

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,6 +49,11 @@ replacements:
   - fieldPaths:
     - webhooks.*.clientConfig.service.name
     select:
+      kind: MutatingWebhookConfiguration
+      name: inferencegraph.serving.kserve.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.name
+    select:
       kind: ValidatingWebhookConfiguration
       name: clusterservingruntime.serving.kserve.io
   - fieldPaths:
@@ -92,6 +97,11 @@ replacements:
     - webhooks.*.clientConfig.service.namespace
     select:
       kind: ValidatingWebhookConfiguration
+      name: inferencegraph.serving.kserve.io
+  - fieldPaths:
+    - webhooks.*.clientConfig.service.namespace
+    select:
+      kind: MutatingWebhookConfiguration
       name: inferencegraph.serving.kserve.io
   - fieldPaths:
     - webhooks.*.clientConfig.service.namespace
@@ -151,6 +161,14 @@ replacements:
       delimiter: '/'
       index: 0
     select:
+      kind: MutatingWebhookConfiguration
+      name: inferencegraph.serving.kserve.io
+  - fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+    select:
       kind: ValidatingWebhookConfiguration
       name: clusterservingruntime.serving.kserve.io
   - fieldPaths:
@@ -175,6 +193,7 @@ patches:
 - path: manager_auth_proxy_patch.yaml
 - path: isvc_mutatingwebhook_cainjection_patch.yaml
 - path: isvc_validatingwebhook_cainjection_patch.yaml
+- path: inferencegraph_mutatingwebhook_cainjection_patch.yaml
 - path: inferencegraph_validatingwebhook_cainjection_patch.yaml
 - path: trainedmodel_validatingwebhook_cainjection_patch.yaml
 - path: clusterservingruntime_validatingwebhook_cainjection_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -132,6 +132,32 @@ webhooks:
           - inferencegraphs
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: inferencegraph.serving.kserve.io
+webhooks:
+  - clientConfig:
+      service:
+        name: $(webhookServiceName)
+        namespace: $(kserveNamespace)
+        path: /mutate-serving-kserve-io-v1alpha1-inferencegraph
+    failurePolicy: Fail
+    name: inferencegraph.kserve-webhook-server.defaulter
+    sideEffects: None
+    admissionReviewVersions: ["v1beta1"]
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferencegraphs
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/pkg/apis/serving/v1alpha1/inference_graph_defaults.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph_defaults.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/kserve/kserve/pkg/constants"
+	utils "github.com/kserve/kserve/pkg/utils"
+)
+
+var defaulterLogger = logf.Log.WithName("inferencegraph-v1alpha1-mutating-webhook")
+
+// +kubebuilder:object:generate=false
+// +k8s:openapi-gen=false
+// InferenceGraphDefaulter sets default values on InferenceGraph resources at admission time.
+//
+// Only minReplicas is defaulted here: both Knative (utils.SetAutoScalingAnnotations) and
+// Standard (hpa reconciler) resolve nil to 1, so writing 1 is behaviour-neutral across modes.
+// maxReplicas, scaleMetric, and timeout are intentionally left unset because their effective
+// defaults differ by deployment mode (see hpa_reconciler.go and utils.go).
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating
+// DeepCopy methods, as it is used only for temporary operations and does not need to be deeply copied.
+type InferenceGraphDefaulter struct{}
+
+// +kubebuilder:webhook:path=/mutate-serving-kserve-io-v1alpha1-inferencegraph,mutating=true,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferencegraphs,verbs=create;update,versions=v1alpha1,name=inferencegraph.kserve-webhook-server.defaulter,admissionReviewVersions=v1beta1
+var _ webhook.CustomDefaulter = &InferenceGraphDefaulter{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (d *InferenceGraphDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	ig, err := utils.Convert[*InferenceGraph](obj)
+	if err != nil {
+		defaulterLogger.Error(err, "Unable to convert object to InferenceGraph")
+		return err
+	}
+	defaulterLogger.Info("Defaulting InferenceGraph", "name", ig.Name, "namespace", ig.Namespace)
+
+	// Only default minReplicas. Do not touch maxReplicas / scaleMetric / timeout:
+	// those resolve differently in Knative vs Standard mode.
+	if ig.Spec.MinReplicas == nil {
+		ig.Spec.MinReplicas = ptr.To(constants.DefaultMinReplicas)
+	}
+	return nil
+}
+
+// SetupInferenceGraphWebhookWithManager registers the InferenceGraph mutating and validating webhooks.
+// Shared by cmd/manager and envtest so admission-path tests exercise production wiring.
+func SetupInferenceGraphWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&InferenceGraph{}).
+		WithDefaulter(&InferenceGraphDefaulter{}).
+		WithValidator(&InferenceGraphValidator{}).
+		Complete()
+}

--- a/pkg/apis/serving/v1alpha1/inference_graph_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph_defaults_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
+)
+
+func TestInferenceGraphDefaulter_Default(t *testing.T) {
+	defaulter := &InferenceGraphDefaulter{}
+
+	tests := []struct {
+		name    string
+		ig      *InferenceGraph
+		want    InferenceGraphSpec
+		wantErr bool
+	}{
+		{
+			name: "defaults minReplicas when unset",
+			ig:   &InferenceGraph{Spec: InferenceGraphSpec{}},
+			want: InferenceGraphSpec{MinReplicas: ptr.To(int32(1))},
+		},
+		{
+			name: "preserves explicit zero for scale-to-zero",
+			ig:   &InferenceGraph{Spec: InferenceGraphSpec{MinReplicas: ptr.To(int32(0))}},
+			want: InferenceGraphSpec{MinReplicas: ptr.To(int32(0))},
+		},
+		{
+			name: "preserves explicit minReplicas",
+			ig:   &InferenceGraph{Spec: InferenceGraphSpec{MinReplicas: ptr.To(int32(5))}},
+			want: InferenceGraphSpec{MinReplicas: ptr.To(int32(5))},
+		},
+		{
+			name: "does not default mode-dependent fields",
+			ig:   &InferenceGraph{Spec: InferenceGraphSpec{}},
+			want: InferenceGraphSpec{
+				MinReplicas:    ptr.To(int32(1)),
+				MaxReplicas:    0,
+				ScaleMetric:    nil,
+				TimeoutSeconds: nil,
+				ScaleTarget:    nil,
+			},
+		},
+		{
+			name: "is idempotent",
+			ig:   &InferenceGraph{Spec: InferenceGraphSpec{}},
+			want: InferenceGraphSpec{MinReplicas: ptr.To(int32(1))},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := defaulter.Default(t.Context(), tt.ig); err != nil {
+				t.Fatalf("Default() unexpected error: %v", err)
+			}
+			if tt.name == "is idempotent" {
+				if err := defaulter.Default(t.Context(), tt.ig); err != nil {
+					t.Fatalf("second Default() unexpected error: %v", err)
+				}
+			}
+			if diff := cmp.Diff(tt.want, tt.ig.Spec); diff != "" {
+				t.Errorf("Spec mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("wrong type returns error", func(t *testing.T) {
+		err := defaulter.Default(t.Context(), &InferenceGraphList{})
+		if err == nil {
+			t.Fatal("Default() expected error for wrong type, got nil")
+		}
+	})
+}

--- a/pkg/apis/serving/v1alpha1/inference_graph_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph_defaults_test.go
@@ -27,10 +27,9 @@ func TestInferenceGraphDefaulter_Default(t *testing.T) {
 	defaulter := &InferenceGraphDefaulter{}
 
 	tests := []struct {
-		name    string
-		ig      *InferenceGraph
-		want    InferenceGraphSpec
-		wantErr bool
+		name string
+		ig   *InferenceGraph
+		want InferenceGraphSpec
 	}{
 		{
 			name: "defaults minReplicas when unset",

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -539,7 +539,7 @@ var _ = Describe("Inference Graph controller test", func() {
 											},
 											Args: []string{
 												"--graph-json",
-												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{}}",
+												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"minReplicas\":1}",
 											},
 											Resources: corev1.ResourceRequirements{
 												Limits: corev1.ResourceList{
@@ -677,7 +677,7 @@ var _ = Describe("Inference Graph controller test", func() {
 											},
 											Args: []string{
 												"--graph-json",
-												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{\"limits\":{\"cpu\":\"123m\",\"memory\":\"123Mi\"},\"requests\":{\"cpu\":\"123m\",\"memory\":\"123Mi\"}}}",
+												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{\"limits\":{\"cpu\":\"123m\",\"memory\":\"123Mi\"},\"requests\":{\"cpu\":\"123m\",\"memory\":\"123Mi\"}},\"minReplicas\":1}",
 											},
 											Resources: corev1.ResourceRequirements{
 												Limits: corev1.ResourceList{
@@ -829,7 +829,7 @@ var _ = Describe("Inference Graph controller test", func() {
 											},
 											Args: []string{
 												"--graph-json",
-												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"affinity\":{\"podAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"weight\":100,\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"serving.kserve.io/inferencegraph\",\"operator\":\"In\",\"values\":[\"singlenode3\"]}]},\"topologyKey\":\"topology.kubernetes.io/zone\"}}]}}}",
+												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"affinity\":{\"podAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"weight\":100,\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"serving.kserve.io/inferencegraph\",\"operator\":\"In\",\"values\":[\"singlenode3\"]}]},\"topologyKey\":\"topology.kubernetes.io/zone\"}}]}},\"minReplicas\":1}",
 											},
 											Resources: corev1.ResourceRequirements{
 												Limits: corev1.ResourceList{
@@ -1567,7 +1567,7 @@ var _ = Describe("Inference Graph controller test", func() {
 											},
 											Args: []string{
 												"--graph-json",
-												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"tolerations\":[{\"key\":\"key1\",\"operator\":\"Equal\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}]}",
+												"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{},\"minReplicas\":1,\"tolerations\":[{\"key\":\"key1\",\"operator\":\"Equal\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}]}",
 											},
 											Resources: corev1.ResourceRequirements{
 												Limits: corev1.ResourceList{
@@ -1614,6 +1614,59 @@ var _ = Describe("Inference Graph controller test", func() {
 			err := k8sClient.Update(context.TODO(), expectedKnService, client.DryRunAll)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(actualKnServiceCreated.Spec).To(BeComparableTo(expectedKnService.Spec))
+		})
+	})
+
+	Context("When creating an InferenceGraph without minReplicas", func() {
+		It("should persist the default minReplicas from the mutating webhook", func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			graphName := "default-minreplicas"
+			serviceKey := types.NamespacedName{Name: graphName, Namespace: "default"}
+			ctx := context.Background()
+			ig := &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.Knative),
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.example.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ig)).Should(Succeed())
+			defer k8sClient.Delete(ctx, ig)
+
+			stored := &v1alpha1.InferenceGraph{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, serviceKey, stored)).To(Succeed())
+				g.Expect(stored.Spec.MinReplicas).NotTo(BeNil())
+				g.Expect(*stored.Spec.MinReplicas).To(Equal(int32(1)))
+				g.Expect(stored.Spec.MaxReplicas).To(Equal(int32(0)))
+				g.Expect(stored.Spec.ScaleMetric).To(BeNil())
+				g.Expect(stored.Spec.TimeoutSeconds).To(BeNil())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/pkg/controller/v1alpha1/inferencegraph/suite_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/suite_test.go
@@ -18,6 +18,7 @@ package inferencegraph
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -29,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
@@ -65,7 +67,11 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		}).SetupWithManager(mgr, deployConfig)
 	}
 
-	envTest := pkgtest.NewEnvTest().
+	webhookManifests := pkgtest.WithWebhookManifests(filepath.Join(pkgtest.ProjectRoot(), "test", "webhooks", "inferencegraph"))
+	envTest := pkgtest.NewEnvTest(webhookManifests).
+		WithWebhooks(func(_ *rest.Config, mgr ctrl.Manager) error {
+			return v1alpha1.SetupInferenceGraphWebhookWithManager(mgr)
+		}).
 		WithControllers(ctrlFunc).
 		// The suite manager/webhook must outlive BeforeSuite node context.
 		Start(context.Background())

--- a/test/webhooks/inferencegraph/manifests.yaml
+++ b/test/webhooks/inferencegraph/manifests.yaml
@@ -1,0 +1,53 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: inferencegraph.serving.kserve.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kserve-webhook-server-service
+        namespace: kserve
+        path: /mutate-serving-kserve-io-v1alpha1-inferencegraph
+    failurePolicy: Fail
+    sideEffects: None
+    name: inferencegraph.kserve-webhook-server.defaulter
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferencegraphs
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: inferencegraph.serving.kserve.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: kserve-webhook-server-service
+        namespace: kserve
+        path: /validate-serving-kserve-io-v1alpha1-inferencegraph
+    failurePolicy: Fail
+    sideEffects: None
+    name: inferencegraph.kserve-webhook-server.validator
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - inferencegraphs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: `/rerun-failed` reruns only failed jobs, `/rerun-all` reruns all jobs, `/rerun-workflow <name>` reruns a specific workflow.
-->

**What this PR does / why we need it**:

`InferenceGraph` had validation webhooks but no mutating/defaulting webhook. Several fields receive defaults only inside the reconciler, so the stored object never shows the effective configuration (`kubectl get` / GitOps drift).

This PR adds a **minReplicas-only** defaulting webhook: when `spec.minReplicas` is unset, admission writes `1` (same value both Knative and Standard modes already apply at reconcile). This is a **partial** fix for #5851 — see design answer below.

**Design question (from #5851):** Should mode-dependent defaults (`maxReplicas`, `scaleMetric`, `timeout`) be applied at admission?

**Answer:** No. Leave them to the reconciler. Evidence:
- `maxReplicas: 0` means *unlimited* in Knative (`utils.SetAutoScalingAnnotations`) but *effectively 1* in Standard HPA — no admission-time value is behaviour-neutral.
- `scaleMetric` defaults to `cpu`@80% (Standard) vs Knative concurrency annotations.
- `timeout` is Knative-only; Standard never reads it. Defaulting it would advertise an unenforced timeout.

Follow-ups (to file against upstream before merge of the official PR):
1. maxReplicas mode-safe defaulting / status surfacing
2. scaleMetric mode-safe defaulting
3. timeout documentation / Knative-only enforcement
4. pin `status.deploymentMode` for InferenceGraph (ISVC already does; IG re-resolves from ConfigMap every reconcile)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5851

**Feature/Issue validation/testing**:

- [x] Unit: `TestInferenceGraphDefaulter_Default` (unset→1, zero preserved, explicit preserved, mode-dependent fields untouched, idempotent, wrong type)
- [x] Envtest: create IG without minReplicas → stored object has `minReplicas=1`, maxReplicas/scaleMetric/timeout unchanged
- [x] HPA regression gate unmodified: `TestCreateHPA|TestGetHPAMetrics` PASS
- [x] Full `./pkg/controller/v1alpha1/inferencegraph/...` suite: 21/21 PASS

How to test:
```bash
go test ./pkg/apis/serving/v1alpha1/ -run TestInferenceGraphDefaulter_Default -v
KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.34 --bin-dir ./bin -p path)" \
  go test ./pkg/controller/v1alpha1/inferencegraph/... -v
```

**Special notes for your reviewer**:

- Shared registration: `SetupInferenceGraphWebhookWithManager` used by both `cmd/manager` and envtest (admission path exercises production wiring).
- Manifests: hand-added MutatingWebhookConfiguration (webhook manifests are not controller-gen generated for IG); kustomize replacements + cert-manager CA injection patch; Helm chart file regenerated via kustomize.
- Existing controller tests that omit minReplicas now expect `minReplicas:1` in router `--graph-json` after admission.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
action required: InferenceGraph now defaults unset minReplicas to 1 at admission. Existing graphs roll once on upgrade because the router --graph-json arg includes the persisted field (scaling semantics unchanged; router does not read minReplicas). Explicit minReplicas: 0 (scale-to-zero) is preserved.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - InferenceGraphs now default to a minimum of 1 replica when `minReplicas` is not specified.
  - Explicit values, including 0 for scale-to-zero, remain unchanged.
  - InferenceGraph create and update requests now receive automatic admission-time defaults and validation.
- **Bug Fixes**
  - Ensures default replica settings are consistently persisted and reflected in deployed InferenceGraph routing configurations.
- **Chores**
  - Added the required webhook configuration and certificate integration for InferenceGraph admission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->